### PR TITLE
Firebase DB 관련 로직 Repository 패턴으로 분리

### DIFF
--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/model/Exceptions.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/model/Exceptions.kt
@@ -1,0 +1,5 @@
+package com.hppk.sw.hppkcommuterbus.data.model
+
+import java.lang.Exception
+
+class BusLineNotFoundExceptions(msg: String): Exception(msg)

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/BusLineRepository.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/BusLineRepository.kt
@@ -1,0 +1,20 @@
+package com.hppk.sw.hppkcommuterbus.data.repository
+
+import com.hppk.sw.hppkcommuterbus.data.model.BusLine
+import com.hppk.sw.hppkcommuterbus.data.repository.source.local.LocalBusLineDao
+import com.hppk.sw.hppkcommuterbus.data.repository.source.remote.FirebaseBusLineDao
+import io.reactivex.Single
+
+class BusLineRepository(
+    private val localBusLineDao: LocalBusLineDao,
+    private val remoteBusLineDao: FirebaseBusLineDao = FirebaseBusLineDao()
+) {
+
+    fun getBusLines(): Single<List<BusLine>> {
+        return remoteBusLineDao.getBusLines()
+    }
+
+    fun getBusLine(id: String): Single<BusLine> {
+        return remoteBusLineDao.getBusLine(id)
+    }
+}

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/BusLineDataSource.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/BusLineDataSource.kt
@@ -1,0 +1,9 @@
+package com.hppk.sw.hppkcommuterbus.data.repository.source
+
+import com.hppk.sw.hppkcommuterbus.data.model.BusLine
+import io.reactivex.Single
+
+interface BusLineDataSource {
+    fun getBusLines(): Single<List<BusLine>>
+    fun getBusLine(id: String): Single<BusLine>
+}

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/local/LocalBusLineDao.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/local/LocalBusLineDao.kt
@@ -1,0 +1,15 @@
+package com.hppk.sw.hppkcommuterbus.data.repository.source.local
+
+import com.hppk.sw.hppkcommuterbus.data.model.BusLine
+import com.hppk.sw.hppkcommuterbus.data.repository.source.BusLineDataSource
+import io.reactivex.Single
+
+class LocalBusLineDao : BusLineDataSource {
+    override fun getBusLines(): Single<List<BusLine>> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getBusLine(id: String): Single<BusLine> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+}

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/remote/FirebaseBusLineDao.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/remote/FirebaseBusLineDao.kt
@@ -1,0 +1,54 @@
+package com.hppk.sw.hppkcommuterbus.data.repository.source.remote
+
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
+import com.hppk.sw.hppkcommuterbus.data.model.BusLine
+import com.hppk.sw.hppkcommuterbus.data.model.BusLineNotFoundExceptions
+import com.hppk.sw.hppkcommuterbus.data.repository.source.BusLineDataSource
+import io.reactivex.Single
+
+class FirebaseBusLineDao(
+    private val database: FirebaseDatabase = FirebaseDatabase.getInstance()
+) : BusLineDataSource {
+
+    override fun getBusLines(): Single<List<BusLine>> = Single.create<List<BusLine>> { emitter ->
+        database.reference
+            .child("bus-line")
+            .addListenerForSingleValueEvent(object : ValueEventListener {
+                override fun onCancelled(err: DatabaseError) {
+                    emitter.onError(err.toException())
+                }
+
+                override fun onDataChange(dataSnapshot: DataSnapshot) {
+                    dataSnapshot.children.mapNotNull { child ->
+                        child.getValue(BusLine::class.java)
+                    }.let { busLines ->
+                        emitter.onSuccess(busLines)
+                    }
+                }
+
+            })
+    }
+
+    override fun getBusLine(id: String): Single<BusLine> = Single.create<BusLine> { emitter ->
+        database.reference
+            .child("bus-line")
+            .child(id)
+            .addListenerForSingleValueEvent(object : ValueEventListener {
+                override fun onCancelled(err: DatabaseError) {
+                    emitter.onError(err.toException())
+                }
+
+                override fun onDataChange(dataSnapshot: DataSnapshot) {
+                    val busLine = dataSnapshot.getValue(BusLine::class.java)
+                    if (busLine == null) {
+                        emitter.onError(BusLineNotFoundExceptions("BusLine [$id] is not exist"))
+                    } else {
+                        emitter.onSuccess(busLine)
+                    }
+                }
+            })
+    }
+}


### PR DESCRIPTION
Firebase DB 관련 로직 Repository 패턴으로 분리
 - 추후 Local DB를 캐시 용으로 쓸지는 모르겠지만, 일단 interface는 추가해두었습니다.
 - View 계층에서는 Repository를 통해 데이터를 가져오기 때문에 데이터가 Firebase에서 오는지, 로컬에서 오는지 알 필요가 없어 집니다.