### PR TITLE
FIX - 버스 정류장 선택 시 앱 죽는 문제 #24

### DIFF
--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/details/LineDetailsActivity.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/details/LineDetailsActivity.kt
@@ -79,7 +79,7 @@ class LineDetailsActivity : AppCompatActivity(), BusStopsAdapter.BusStopClickLis
         }
 
         mapView.poiItems.first {
-            it.itemName == busStop.name
+            it.itemName == if (CommuterBusApplication.language =="ko") busStop.nameKr else busStop.name
         }.let {
             mapView.selectPOIItem(it, true)
 


### PR DESCRIPTION
Map에 Marker 추가 시에는 busStop.nameKr로 등록하고
List에서 항목 선택 시 filter에서는 busStop.name으로 찾다 보니 아이템이 존재하지 않아 발생한 문제입니다.