### PR TITLE
Alarm 울리지 않는 문제 수정

### DIFF
--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/application/CommuterBusApplication.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/application/CommuterBusApplication.kt
@@ -2,6 +2,7 @@ package com.hppk.sw.hppkcommuterbus.application
 
 import android.os.Build
 import androidx.multidex.MultiDexApplication
+import com.hppk.sw.hppkcommuterbus.manager.NotiManager
 import java.util.*
 
 class CommuterBusApplication : MultiDexApplication () {
@@ -14,6 +15,7 @@ class CommuterBusApplication : MultiDexApplication () {
     override fun onCreate() {
         super.onCreate()
         language = getLanguage()
+        NotiManager.createChannel(this)
     }
 
     private fun getLanguage(): String {

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/manager/BusAlarmManager.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/manager/BusAlarmManager.kt
@@ -4,6 +4,7 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.google.android.gms.location.Geofence
 import com.google.android.gms.location.GeofencingClient
 import com.google.android.gms.location.GeofencingRequest
@@ -13,12 +14,15 @@ import com.hppk.sw.hppkcommuterbus.receiver.AlarmReceiver
 import com.hppk.sw.hppkcommuterbus.receiver.GeofenceBroadcastReceiver
 import com.hppk.sw.hppkcommuterbus.receiver.KEY_ALARM_BUS_STOP
 import com.hppk.sw.hppkcommuterbus.receiver.KEY_ALARM_MESSAGE
+import java.text.SimpleDateFormat
 import java.util.*
 
 
 class BusAlarmManager(
     private val context: Context
 ) {
+
+    private val TAG = BusAlarmManager::class.java.simpleName
     private val alarmManager: AlarmManager by lazy { context.getSystemService(Context.ALARM_SERVICE) as AlarmManager }
     private val geofencingClient: GeofencingClient by lazy {
         LocationServices.getGeofencingClient(
@@ -28,14 +32,10 @@ class BusAlarmManager(
 
     fun register(alarmId: Int, busStop: BusStop, time: Long, msg: String) {
         val intent = Intent(context, AlarmReceiver::class.java)
-            .putExtra(KEY_ALARM_MESSAGE, msg)
-            .putExtra(KEY_ALARM_BUS_STOP, busStop)
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            alarmId,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
-        )
+        intent.putExtra(KEY_ALARM_MESSAGE, msg)
+        intent.putExtra(KEY_ALARM_BUS_STOP, busStop)
+
+        val pendingIntent = PendingIntent.getBroadcast(context, alarmId, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
         val calendar = Calendar.getInstance()
         val now = calendar.timeInMillis
@@ -49,12 +49,7 @@ class BusAlarmManager(
             calendar.add(Calendar.DAY_OF_MONTH, 1)
         }
 
-        alarmManager.setRepeating(
-            AlarmManager.RTC_WAKEUP,
-            calendar.timeInMillis - time,
-            AlarmManager.INTERVAL_DAY,
-            pendingIntent
-        )
+        alarmManager.setExact(AlarmManager.RTC_WAKEUP, calendar.timeInMillis - time, pendingIntent)
     }
 
     fun register(alarmId: Int, busStop: BusStop, msg: String) {

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/manager/NotiManager.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/manager/NotiManager.kt
@@ -7,15 +7,19 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.hppk.sw.hppkcommuterbus.R
 import com.hppk.sw.hppkcommuterbus.ui.MainActivity
+import com.hppk.sw.hppkcommuterbus.ui.splash.SplashActivity
 
 
 private const val CHANNEL_ID = "hppk-commuter-bus-noti-channel-id"
 
 object NotiManager {
+
+    private val TAG = NotiManager::class.java.simpleName
 
     fun createChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -31,7 +35,7 @@ object NotiManager {
     }
 
     fun notify(context: Context, title: String, text: String) {
-        val intent = Intent(context, MainActivity::class.java).apply {
+        val intent = Intent(context, SplashActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
         val pendingIntent = PendingIntent.getActivity(context, 10, intent, PendingIntent.FLAG_UPDATE_CURRENT)
@@ -41,6 +45,7 @@ object NotiManager {
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setSmallIcon(R.mipmap.ic_launcher)
         with(NotificationManagerCompat.from(context)) {
             notify(123, notiBuilder.build())
         }

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/receiver/AlarmReceiver.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/receiver/AlarmReceiver.kt
@@ -3,6 +3,7 @@ package com.hppk.sw.hppkcommuterbus.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.hppk.sw.hppkcommuterbus.R
 import com.hppk.sw.hppkcommuterbus.manager.NotiManager
 
@@ -11,7 +12,10 @@ const val KEY_ALARM_BUS_STOP = "KEY_ALARM_BUS_STOP"
 
 class AlarmReceiver : BroadcastReceiver() {
 
+    private val TAG = AlarmReceiver::class.java.simpleName
+
     override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "[BUS] onReceive")
         if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
             handleBootCompleted(context)
         } else {
@@ -28,6 +32,7 @@ class AlarmReceiver : BroadcastReceiver() {
             intent.hasExtra(KEY_ALARM_MESSAGE) -> intent.getStringExtra(KEY_ALARM_MESSAGE)
             else -> ""
         }
+        Log.d(TAG, "[BUS] handleAlarm - message: $message")
         NotiManager.notify(context, context.getString(R.string.bus_alarm), message)
     }
 

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/splash/SplashActivity.kt
@@ -89,7 +89,7 @@ class SplashActivity : AppCompatActivity(), SplashContract.View {
             intent.putExtra(KEY_BUS_LINES, busLines.toTypedArray())
             startActivity(intent)
             finish()
-        }, 2000)
+        }, 1000)
     }
 
     private fun printHashKey() {


### PR DESCRIPTION
AlarmManage.setRepeating이 동작하지 않아 AlarmManage.setExact으로 변경하였습니다.

알아보니 setRepeating은 알람 시간 정확도가 떨어지니 정확한 시간에 알림을 주는 것이 필요하다면
setExact를 이용하라고 하네요.
거기에 주기적인 알람을 이용하고 싶다면 setRepeating 대신 setExact를 사용하고 대신 직접(수동적으로) 주기적으로 알람을 등록해야 합니다.

본 PR은 setExact만 적용한 내용으로,
주기적으로 다시 알람 등록하는 로직이 필요합니다.
이 부분은 좀더 아키텍쳐를 고민해봐야 할 것 같아요.