### PR TITLE
Favorite 가져오는 로직 FavoriteRepo로 분리

### DIFF
--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/local/LocalDataSource.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/local/LocalDataSource.kt
@@ -7,27 +7,8 @@ import com.google.gson.reflect.TypeToken
 import com.hppk.sw.hppkcommuterbus.data.model.BusStop
 
 object LocalDataSource {
-    private const val FAVORITES_ID = "FAVORITES_ID"
     private const val TIME_ALARM_ID = "TIME_ALARM_ID"
     private const val LOCATION_ALARM_ID = "LOCATION_ALARM_ID"
-
-
-    fun saveFavoriteID(pref: SharedPreferences,favoritesDataList : List<String>) {
-        val set = HashSet<String>()
-        set.addAll(favoritesDataList)
-        pref.edit().putStringSet(FAVORITES_ID, set).apply()
-
-    }
-
-    fun loadFavoriteID (pref: SharedPreferences) : MutableList<String> {
-        val dataList = ArrayList<String>()
-
-        val set = pref.getStringSet(FAVORITES_ID, null)
-        if (set != null) {
-            dataList.addAll(set)
-        }
-        return dataList
-    }
 
     fun saveTimeAlarm(pref: SharedPreferences, busStopList : List<BusStop>) {
         val busStops = Gson().toJson(busStopList)

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/FavoriteRepository.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/FavoriteRepository.kt
@@ -1,0 +1,25 @@
+package com.hppk.sw.hppkcommuterbus.data.repository
+
+import io.reactivex.Completable
+import io.reactivex.Single
+
+
+class FavoriteRepository(
+    private val localFavoriteDataSource: FavoriteDataSource,
+    private val remoteFavoriteDataSource: FavoriteDataSource? = null
+) {
+
+    fun saveFavoriteID(favoritesDataList: List<String>): Completable {
+        return localFavoriteDataSource.saveFavoriteId(favoritesDataList)
+    }
+
+    fun getFavoriteID(): Single<List<String>> {
+        return localFavoriteDataSource.getFavoriteIds()
+    }
+
+}
+
+interface FavoriteDataSource {
+    fun saveFavoriteId(favoriteIds: List<String>): Completable
+    fun getFavoriteIds(): Single<List<String>>
+}

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/local/PrefFavoriteDao.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/data/repository/source/local/PrefFavoriteDao.kt
@@ -1,0 +1,25 @@
+package com.hppk.sw.hppkcommuterbus.data.repository.source.local
+
+import android.content.SharedPreferences
+import com.hppk.sw.hppkcommuterbus.data.repository.FavoriteDataSource
+import io.reactivex.Completable
+import io.reactivex.Single
+
+private const val FAVORITES_ID = "FAVORITES_ID"
+
+class PrefFavoriteDao(
+    private val pref: SharedPreferences
+) : FavoriteDataSource {
+
+    override fun saveFavoriteId(favoriteIds: List<String>) = Completable.create { emitter ->
+        if (pref.edit().putStringSet(FAVORITES_ID, favoriteIds.toSet()).commit()) {
+            emitter.onComplete()
+        } else {
+            emitter.onError(Exception("Saveing favorites failed"))
+        }
+    }
+
+    override fun getFavoriteIds() = Single.create<List<String>> { emitter ->
+        emitter.onSuccess(pref.getStringSet(FAVORITES_ID, setOf()).toList())
+    }
+}

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/buslines/BusLinesContract.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/buslines/BusLinesContract.kt
@@ -5,10 +5,13 @@ import android.content.SharedPreferences
 interface BusLinesContract {
 
     interface View {
-        fun onFavoritesListLoaded(favoritesList : MutableList<String>)
+        fun onFavoritesListLoaded(favoritesList: List<String>)
+        fun onFavoritesSaved()
     }
 
     interface Presenter {
+        fun unsubscribe()
         fun loadRecent(pref: SharedPreferences)
+        fun saveFavoriteIds(favoritesBusLineList: List<String>)
     }
 }

--- a/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/buslines/BusLinesPresenter.kt
+++ b/app/src/main/java/com/hppk/sw/hppkcommuterbus/ui/buslines/BusLinesPresenter.kt
@@ -1,16 +1,54 @@
 package com.hppk.sw.hppkcommuterbus.ui.buslines
 
 import android.content.SharedPreferences
+import android.util.Log
 import com.hppk.sw.hppkcommuterbus.data.local.LocalDataSource
+import com.hppk.sw.hppkcommuterbus.data.repository.FavoriteRepository
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
 
 class BusLinesPresenter (
-    private val view : BusLinesContract.View
+    private val view : BusLinesContract.View,
+    private val favoriteRepository: FavoriteRepository,
+    private val ioScheduler: Scheduler = Schedulers.io(),
+    private val uiScheduler: Scheduler = AndroidSchedulers.mainThread(),
+    private val disposable: CompositeDisposable = CompositeDisposable()
 ) : BusLinesContract.Presenter {
+
+    private val TAG = BusLinesPresenter::class.java.simpleName
+
+    override fun unsubscribe() {
+        disposable.clear()
+    }
+
+    override fun saveFavoriteIds(favoritesBusLineList: List<String>) {
+        disposable.add(
+            favoriteRepository.saveFavoriteID(favoritesBusLineList)
+                .subscribeOn(ioScheduler)
+                .observeOn(uiScheduler)
+                .subscribe({
+                    view.onFavoritesSaved()
+                }, { t ->
+                    Log.e(TAG, "[BUS] saveFavoriteIds - failed:${t.message}", t)
+                })
+        )
+    }
+
     private lateinit var dataList :MutableList<String>
 
     override fun loadRecent(pref:SharedPreferences) {
-        dataList = LocalDataSource.loadFavoriteID(pref)
-        view.onFavoritesListLoaded(dataList)
+        disposable.add(
+            favoriteRepository.getFavoriteID()
+                .subscribeOn(ioScheduler)
+                .observeOn(uiScheduler)
+                .subscribe({
+                    view.onFavoritesListLoaded(it)
+                }, { t ->
+                    Log.e(TAG, "[BUS] loadRecent - failed:${t.message}", t)
+                })
+        )
     }
 
 }


### PR DESCRIPTION
* LocalDataSource에서 Favorite과 Alarm을 모두 관리하고 있어 FavoriteRepo로 별도 분리
* BusLinesFragment에서 직접 LocalDataSource를 통해 저장하는 로직을
  BusLinesPresenter로 분리하고 다시 FavoriteRepo를 통해 저장하도록 역할 분리